### PR TITLE
Annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
             <version>5.0.0-M3</version>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>io.github.lukehutch</groupId>
+            <artifactId>fast-classpath-scanner</artifactId>
+            <version>2.4.5</version>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/src/main/java/com/github/pyknic/stiletto/InjectorBuilder.java
+++ b/src/main/java/com/github/pyknic/stiletto/InjectorBuilder.java
@@ -57,6 +57,8 @@ public interface InjectorBuilder {
     default <T> InjectorBuilder withType(Class<T> clazz) {
         return withType(clazz, clazz.getName());
     }
+    
+    <T> InjectorBuilder fromProviders();
 
     /**
      * Builds the dependency injector, rendering it immutable. This builder

--- a/src/main/java/com/github/pyknic/stiletto/InjectorBuilder.java
+++ b/src/main/java/com/github/pyknic/stiletto/InjectorBuilder.java
@@ -58,7 +58,22 @@ public interface InjectorBuilder {
         return withType(clazz, clazz.getName());
     }
     
-    <T> InjectorBuilder fromProviders();
+    /**
+     * Adds all types that are annotated with the {@link Provider} annotation to
+     * the injector being built, so that them and all of their ancestors can be
+     * dependency injected. Each type found by recursively scanning the class
+     * path from the parameter {@code scanSpec}, 
+     * <a href="https://github.com/lukehutch/fast-classpath-scanner/wiki/2.-Constructor#scan-spec">
+     * using these semantics</a>, are added to the injector via the 
+     * {@link #withType(Class, String)} method.
+     * <p>
+     * For simple usage, you may leave the {@code scanSpec} parameter empty
+     *
+     * @param <T>       the injectable (implementation) type
+     * @param scanSpec  the scan specifications
+     * @return          this builder
+     */
+    <T> InjectorBuilder fromProviders(String... scanSpec);
 
     /**
      * Builds the dependency injector, rendering it immutable. This builder

--- a/src/main/java/com/github/pyknic/stiletto/Provider.java
+++ b/src/main/java/com/github/pyknic/stiletto/Provider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Emil Forslund.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pyknic.stiletto;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Base annotation for methods that provides an implementation for a certain
+ * class.
+ *
+ * @author Simon Jonasson2
+ * @since 1.0.2
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Provider {
+    String value() default "";
+}

--- a/src/main/java/com/github/pyknic/stiletto/Provider.java
+++ b/src/main/java/com/github/pyknic/stiletto/Provider.java
@@ -23,8 +23,8 @@ import java.lang.annotation.Target;
 /** Base annotation for methods that provides an implementation for a certain
  * class.
  *
- * @author Simon Jonasson2
- * @since 1.0.2
+ * @author Simon Jonasson
+ * @since 1.0.3
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/github/pyknic/stiletto/internal/InjectorBuilderImpl.java
+++ b/src/main/java/com/github/pyknic/stiletto/internal/InjectorBuilderImpl.java
@@ -20,6 +20,7 @@ import com.github.pyknic.stiletto.Inject;
 import com.github.pyknic.stiletto.Injector;
 import com.github.pyknic.stiletto.InjectorBuilder;
 import com.github.pyknic.stiletto.InjectorException;
+import com.github.pyknic.stiletto.Provider;
 import com.github.pyknic.stiletto.internal.graph.Node;
 import com.github.pyknic.stiletto.internal.graph.NodeImpl;
 import com.github.pyknic.stiletto.internal.util.StringUtil;
@@ -32,6 +33,8 @@ import java.util.stream.Stream;
 
 import static com.github.pyknic.stiletto.internal.util.ReflectionUtil.traverseAncestors;
 import static com.github.pyknic.stiletto.internal.util.ReflectionUtil.traverseFields;
+import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
+import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.joining;
@@ -98,6 +101,19 @@ public final class InjectorBuilderImpl implements InjectorBuilder {
         return this;
     }
 
+    @Override
+    public <T> InjectorBuilder fromProviders() {
+        InjectorBuilder b = this;
+        new FastClasspathScanner().matchClassesWithAnnotation(Provider.class, c -> {
+            Provider p = c.getAnnotation(Provider.class);
+            if(p.value().isEmpty())
+                b.withType(c);
+            else
+                b.withType(c, p.value());
+        });
+        return this;
+    }
+    
     @Override
     public Injector build() {
         final Map<String, Object> byQualifier = new HashMap<>();

--- a/src/main/java/com/github/pyknic/stiletto/internal/InjectorBuilderImpl.java
+++ b/src/main/java/com/github/pyknic/stiletto/internal/InjectorBuilderImpl.java
@@ -60,9 +60,9 @@ public final class InjectorBuilderImpl implements InjectorBuilder {
     }
 
     @Override
-    public <T> InjectorBuilder fromProviders() {
+    public <T> InjectorBuilder fromProviders(String... scanSpec) {
         InjectorBuilder b = this;
-        new FastClasspathScanner().matchClassesWithAnnotation(Provider.class, c -> {
+        new FastClasspathScanner(scanSpec).matchClassesWithAnnotation(Provider.class, c -> {
             Provider p = c.getAnnotation(Provider.class);
             if(p.value().isEmpty())
                 b.withType(c);

--- a/src/main/java/com/github/pyknic/stiletto/internal/InjectorBuilderImpl.java
+++ b/src/main/java/com/github/pyknic/stiletto/internal/InjectorBuilderImpl.java
@@ -30,7 +30,6 @@ import static com.github.pyknic.stiletto.internal.InjectorBuilderUtil.findNodes;
 import static com.github.pyknic.stiletto.internal.util.ReflectionUtil.traverseAncestors;
 import static com.github.pyknic.stiletto.internal.util.ReflectionUtil.traverseFields;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
-import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Optional.ofNullable;
 import static java.util.Collections.unmodifiableMap;
@@ -69,7 +68,7 @@ public final class InjectorBuilderImpl implements InjectorBuilder {
                 b.withType(c);
             else
                 b.withType(c, p.value());
-        });
+        }).scan();
         return this;
     }
     

--- a/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
+++ b/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since  1.0.3
  */
 @DisplayName("InjectorAnnotation")
-public class InjectorAnnotationTest {
+class InjectorAnnotationTest {
 
     @Test
     @DisplayName(".has(Class)")

--- a/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
+++ b/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
@@ -38,7 +38,7 @@ public class InjectorAnnotationTest {
     @DisplayName(".has(Class)")
     public void has() {
         final Injector inj = Injector.builder()
-            .fromProviders()
+            .fromProviders("com.github.pyknic.stiletto.testtype")
             .build();
 
         assertTrue(inj.has(CompA.class), "CompA interface");
@@ -53,7 +53,7 @@ public class InjectorAnnotationTest {
     @DisplayName(".getOrThrow(Class)")
     public void getOrThrow() {
         final Injector inj = Injector.builder()
-            .fromProviders()
+            .fromProviders(CompA.class.getPackage().getName())
             .build();
 
         assertNotNull(inj.getOrThrow(CompA.class), "CompA interface");
@@ -75,7 +75,7 @@ public class InjectorAnnotationTest {
     @DisplayName(".get(Class)")
     public void get() {
         final Injector inj = Injector.builder()
-            .fromProviders()
+            .fromProviders(CompA.class.getPackage().getName())
             .build();
 
         assertTrue(inj.get(CompA.class).isPresent(), "CompA interface");
@@ -90,7 +90,7 @@ public class InjectorAnnotationTest {
     @DisplayName(".has(String)")
     public void hasQualifier() {
         final Injector inj = Injector.builder()
-            .fromProviders()
+            .fromProviders(CompA.class.getPackage().getName())
             .build();
 
         assertTrue(inj.has("a"), "'a' qualifier");
@@ -103,7 +103,7 @@ public class InjectorAnnotationTest {
     @DisplayName(".getOrThrow(String)")
     public void getOrThrowQualifier() {
         final Injector inj = Injector.builder()
-            .fromProviders()
+            .fromProviders(CompA.class.getPackage().getName())
             .build();
 
         assertNotNull(inj.getOrThrow(CompA.class), "CompA interface");
@@ -143,11 +143,43 @@ public class InjectorAnnotationTest {
     @DisplayName(".get(String)")
     public void getQualifier() {
         final Injector inj = Injector.builder()
+            .fromProviders(CompA.class.getPackage().getName())
+            .build();
+
+        assertTrue(inj.get("a").isPresent(), "'a' qualifier");
+        assertTrue(inj.get("b").isPresent(), "'b' qualifier");
+        assertFalse(inj.get("c").isPresent(), "'c' qualifier");
+    }
+    
+    @Test
+    @DisplayName(".fromProviders()")
+    public void fromProviderSpecs(){
+        
+        // Find the types when we scan the entire class path
+        final Injector inj = Injector.builder()
             .fromProviders()
             .build();
 
         assertTrue(inj.get("a").isPresent(), "'a' qualifier");
         assertTrue(inj.get("b").isPresent(), "'b' qualifier");
         assertFalse(inj.get("c").isPresent(), "'c' qualifier");
+        
+        // Also find the types when we point to the correct pacakge root 
+        final Injector inj2 = Injector.builder()
+            .fromProviders(InjectorAnnotationTest.class.getPackage().getName() + ".testtype")
+            .build();
+
+        assertTrue(inj2.get("a").isPresent(), "'a' qualifier");
+        assertTrue(inj2.get("b").isPresent(), "'b' qualifier");
+        assertFalse(inj2.get("c").isPresent(), "'c' qualifier");
+        
+        // Don't find the types when we point to the wrong package root
+        final Injector inj3 = Injector.builder()
+            .fromProviders(InjectorAnnotationTest.class.getPackage().getName() + ".testtype2")
+            .build();
+
+        assertFalse(inj3.get("a").isPresent(), "'a' qualifier");
+        assertFalse(inj3.get("b").isPresent(), "'b' qualifier");
+        assertFalse(inj3.get("c").isPresent(), "'c' qualifier");
     }
 }

--- a/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
+++ b/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
@@ -36,7 +36,7 @@ public class InjectorAnnotationTest {
 
     @Test
     @DisplayName(".has(Class)")
-    public void has() {
+    void has() {
         final Injector inj = Injector.builder()
             .fromProviders("com.github.pyknic.stiletto.testtype")
             .build();
@@ -51,7 +51,7 @@ public class InjectorAnnotationTest {
 
     @Test
     @DisplayName(".getOrThrow(Class)")
-    public void getOrThrow() {
+    void getOrThrow() {
         final Injector inj = Injector.builder()
             .fromProviders(CompA.class.getPackage().getName())
             .build();
@@ -73,7 +73,7 @@ public class InjectorAnnotationTest {
 
     @Test
     @DisplayName(".get(Class)")
-    public void get() {
+    void get() {
         final Injector inj = Injector.builder()
             .fromProviders(CompA.class.getPackage().getName())
             .build();
@@ -88,7 +88,7 @@ public class InjectorAnnotationTest {
 
     @Test
     @DisplayName(".has(String)")
-    public void hasQualifier() {
+    void hasQualifier() {
         final Injector inj = Injector.builder()
             .fromProviders(CompA.class.getPackage().getName())
             .build();
@@ -101,7 +101,7 @@ public class InjectorAnnotationTest {
 
     @Test
     @DisplayName(".getOrThrow(String)")
-    public void getOrThrowQualifier() {
+    void getOrThrowQualifier() {
         final Injector inj = Injector.builder()
             .fromProviders(CompA.class.getPackage().getName())
             .build();
@@ -141,7 +141,7 @@ public class InjectorAnnotationTest {
 
     @Test
     @DisplayName(".get(String)")
-    public void getQualifier() {
+    void getQualifier() {
         final Injector inj = Injector.builder()
             .fromProviders(CompA.class.getPackage().getName())
             .build();
@@ -153,7 +153,7 @@ public class InjectorAnnotationTest {
     
     @Test
     @DisplayName(".fromProviders()")
-    public void fromProviderSpecs(){
+    void fromProviderSpecs(){
         
         // Find the types when we scan the entire class path
         final Injector inj = Injector.builder()

--- a/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
+++ b/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
@@ -16,174 +16,138 @@
  */
 package com.github.pyknic.stiletto;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import com.github.pyknic.stiletto.testtype.CompA;
+import com.github.pyknic.stiletto.testtype.CompAImpl;
+import com.github.pyknic.stiletto.testtype.CompAImpl2;
+import com.github.pyknic.stiletto.testtype.CompB;
+import com.github.pyknic.stiletto.testtype.CompBImpl;
+import com.github.pyknic.stiletto.testtype.CompC;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 /**
- * @author Simon Jonasson
- * @since 1.0.2
+ * @author Emil Forslund & Simon Jonasson
+ * @since  1.0.3
  */
 @DisplayName("InjectorAnnotation")
-public class InjectorAnnotationTest
-{
+public class InjectorAnnotationTest {
 
-	private interface CompA
-	{
-	}
+    @Test
+    @DisplayName(".has(Class)")
+    public void has() {
+        final Injector inj = Injector.builder()
+            .fromProviders()
+            .build();
 
-	private interface CompB
-	{
-	}
+        assertTrue(inj.has(CompA.class), "CompA interface");
+        assertTrue(inj.has(CompB.class), "CompB interface");
+        assertFalse(inj.has(CompC.class), "CompC interface");
 
-	private interface CompC
-	{
-	}
+        assertTrue(inj.has(CompAImpl.class), "CompA class");
+        assertTrue(inj.has(CompBImpl.class), "CompB class");
+    }
 
-	@Provider("a")
-	private static final class CompAImpl implements CompA
-	{
-	}
+    @Test
+    @DisplayName(".getOrThrow(Class)")
+    public void getOrThrow() {
+        final Injector inj = Injector.builder()
+            .fromProviders()
+            .build();
 
-	@Provider("a2")
-	private static final class CompAImpl2 implements CompA
-	{
-	}
+        assertNotNull(inj.getOrThrow(CompA.class), "CompA interface");
+        assertNotNull(inj.getOrThrow(CompB.class), "CompB interface");
+        assertNotNull(inj.getOrThrow(CompAImpl.class), "CompA class");
+        assertNotNull(inj.getOrThrow(CompBImpl.class), "CompB class");
+        assertThrows(InjectorException.class, () -> {
+            inj.getOrThrow(CompC.class);
+        });
 
-	@Provider("b")
-	private static final class CompBImpl implements CompA, CompB
-	{
-		private final CompA wrapped;
-		private final CompA wrapped2;
+        assertEquals(CompBImpl.class, inj.getOrThrow(CompA.class).getClass(), "CompA is a CompBImpl (most recent added)");
+        assertEquals(CompBImpl.class, inj.getOrThrow(CompB.class).getClass(), "CompB is a CompBImpl");
 
-		// Should not be invoked.
-		CompBImpl()
-		{
-			wrapped = null;
-			wrapped2 = null;
-		}
+        assertNotNull(inj.getOrThrow(CompBImpl.class).wrapped, "Test wrapped instance");
+        assertEquals(CompAImpl.class, inj.getOrThrow(CompBImpl.class).wrapped.getClass(), "Test wrapped instance type");
+    }
 
-		@Inject
-		CompBImpl(@Inject("a") CompA wrapped, CompA second)
-		{
-			this.wrapped = wrapped;
-			this.wrapped2 = second;
-		}
-	}
+    @Test
+    @DisplayName(".get(Class)")
+    public void get() {
+        final Injector inj = Injector.builder()
+            .fromProviders()
+            .build();
 
-	@Test
-	@DisplayName(".has(Class)")
-	public void has()
-	{
-		final Injector inj = Injector.builder().fromProviders().build();
+        assertTrue(inj.get(CompA.class).isPresent(), "CompA interface");
+        assertTrue(inj.get(CompB.class).isPresent(), "CompB interface");
+        assertFalse(inj.get(CompC.class).isPresent(), "CompC interface");
 
-		assertTrue(inj.has(CompA.class), "CompA interface");
-		assertTrue(inj.has(CompB.class), "CompB interface");
-		assertFalse(inj.has(CompC.class), "CompC interface");
+        assertTrue(inj.get(CompAImpl.class).isPresent(), "CompA class");
+        assertTrue(inj.get(CompBImpl.class).isPresent(), "CompB class");
+    }
 
-		assertTrue(inj.has(CompAImpl.class), "CompA class");
-		assertTrue(inj.has(CompBImpl.class), "CompB class");
-	}
+    @Test
+    @DisplayName(".has(String)")
+    public void hasQualifier() {
+        final Injector inj = Injector.builder()
+            .fromProviders()
+            .build();
 
-	@Test
-	@DisplayName(".getOrThrow(Class)")
-	public void getOrThrow()
-	{
-		final Injector inj = Injector.builder().fromProviders().build();
+        assertTrue(inj.has("a"), "'a' qualifier");
+        assertTrue(inj.has("a2"), "'a2' qualifier");
+        assertTrue(inj.has("b"), "'b' qualifier");
+        assertFalse(inj.has("c"), "'c' qualifier");
+    }
 
-		assertNotNull(inj.getOrThrow(CompA.class), "CompA interface");
-		assertNotNull(inj.getOrThrow(CompB.class), "CompB interface");
-		assertNotNull(inj.getOrThrow(CompAImpl.class), "CompA class");
-		assertNotNull(inj.getOrThrow(CompBImpl.class), "CompB class");
-		assertThrows(InjectorException.class, () -> {
-			inj.getOrThrow(CompC.class);
-		});
+    @Test
+    @DisplayName(".getOrThrow(String)")
+    public void getOrThrowQualifier() {
+        final Injector inj = Injector.builder()
+            .fromProviders()
+            .build();
 
-		assertEquals(CompBImpl.class, inj.getOrThrow(CompA.class).getClass(), "CompA is a CompBImpl (most recent added)");
-		assertEquals(CompBImpl.class, inj.getOrThrow(CompB.class).getClass(), "CompB is a CompBImpl");
+        assertNotNull(inj.getOrThrow(CompA.class), "CompA interface");
+        assertNotNull(inj.getOrThrow(CompB.class), "CompB interface");
+        assertNotNull(inj.getOrThrow(CompAImpl.class), "CompA class");
+        assertNotNull(inj.getOrThrow(CompBImpl.class), "CompB class");
+        assertThrows(InjectorException.class, () -> {
+            inj.getOrThrow(CompC.class);
+        });
 
-		assertNotNull(inj.getOrThrow(CompBImpl.class).wrapped, "Test wrapped instance");
-		assertEquals(CompAImpl.class, inj.getOrThrow(CompBImpl.class).wrapped.getClass(), "Test wrapped instance type");
-	}
+        assertNotNull(inj.getOrThrow("a"), "'a' qualifier");
+        assertNotNull(inj.getOrThrow("a2"), "'a2' qualifier");
+        assertNotNull(inj.getOrThrow("b"), "'b' qualifier");
+        assertThrows(InjectorException.class, () -> {
+            inj.getOrThrow("c");
+        });
 
-	@Test
-	@DisplayName(".get(Class)")
-	public void get()
-	{
-		final Injector inj = Injector.builder().fromProviders().build();
+        assertEquals(CompBImpl.class, inj.getOrThrow(CompA.class).getClass(), "CompA is a CompBImpl (most recent added)");
+        assertEquals(CompBImpl.class, inj.getOrThrow(CompB.class).getClass(), "CompB is a CompBImpl");
 
-		assertTrue(inj.get(CompA.class).isPresent(), "CompA interface");
-		assertTrue(inj.get(CompB.class).isPresent(), "CompB interface");
-		assertFalse(inj.get(CompC.class).isPresent(), "CompC interface");
+        assertEquals(CompAImpl.class, inj.getOrThrow("a").getClass(), "'a' is a CompAImpl");
+        assertEquals(CompAImpl2.class, inj.getOrThrow("a2").getClass(), "'a2' is a CompAImpl2");
+        assertEquals(CompBImpl.class, inj.getOrThrow("b").getClass(), "'b' is a CompBImpl");
 
-		assertTrue(inj.get(CompAImpl.class).isPresent(), "CompA class");
-		assertTrue(inj.get(CompBImpl.class).isPresent(), "CompB class");
-	}
+        assertNotNull(inj.getOrThrow(CompBImpl.class).wrapped, "Test wrapped instance");
+        assertNotNull(inj.getOrThrow(CompBImpl.class).wrapped2, "Test wrapped2 instance");
+        assertEquals(CompAImpl.class, inj.getOrThrow(CompBImpl.class).wrapped.getClass(), "Test wrapped instance type");
+        assertEquals(CompAImpl2.class, inj.getOrThrow(CompBImpl.class).wrapped2.getClass(), "Test wrapped2 instance type (most recent added)");
 
-	@Test
-	@DisplayName(".has(String)")
-	public void hasQualifier()
-	{
-		final Injector inj = Injector.builder().fromProviders().build();
+        assertNotNull(((CompBImpl) inj.getOrThrow("b")).wrapped, "Test wrapped instance");
+        assertNotNull(((CompBImpl) inj.getOrThrow("b")).wrapped2, "Test wrapped2 instance");
+        assertEquals(CompAImpl.class, ((CompBImpl) inj.getOrThrow("b")).wrapped.getClass(), "Test wrapped instance type");
+        assertEquals(CompAImpl2.class, ((CompBImpl) inj.getOrThrow("b")).wrapped2.getClass(), "Test wrapped2 instance type (most recent added)");
+    }
 
-		assertTrue(inj.has("a"), "'a' qualifier");
-		assertTrue(inj.has("a2"), "'a2' qualifier");
-		assertTrue(inj.has("b"), "'b' qualifier");
-		assertFalse(inj.has("c"), "'c' qualifier");
-	}
+    @Test
+    @DisplayName(".get(String)")
+    public void getQualifier() {
+        final Injector inj = Injector.builder()
+            .fromProviders()
+            .build();
 
-	@Test
-	@DisplayName(".getOrThrow(String)")
-	public void getOrThrowQualifier()
-	{
-		final Injector inj = Injector.builder().fromProviders().build();
-
-		assertNotNull(inj.getOrThrow(CompA.class), "CompA interface");
-		assertNotNull(inj.getOrThrow(CompB.class), "CompB interface");
-		assertNotNull(inj.getOrThrow(CompAImpl.class), "CompA class");
-		assertNotNull(inj.getOrThrow(CompBImpl.class), "CompB class");
-		assertThrows(InjectorException.class, () -> {
-			inj.getOrThrow(CompC.class);
-		});
-
-		assertNotNull(inj.getOrThrow("a"), "'a' qualifier");
-		assertNotNull(inj.getOrThrow("a2"), "'a2' qualifier");
-		assertNotNull(inj.getOrThrow("b"), "'b' qualifier");
-		assertThrows(InjectorException.class, () -> {
-			inj.getOrThrow("c");
-		});
-
-		assertEquals(CompBImpl.class, inj.getOrThrow(CompA.class).getClass(), "CompA is a CompBImpl (most recent added)");
-		assertEquals(CompBImpl.class, inj.getOrThrow(CompB.class).getClass(), "CompB is a CompBImpl");
-
-		assertEquals(CompAImpl.class, inj.getOrThrow("a").getClass(), "'a' is a CompAImpl");
-		assertEquals(CompAImpl2.class, inj.getOrThrow("a2").getClass(), "'a2' is a CompAImpl2");
-		assertEquals(CompBImpl.class, inj.getOrThrow("b").getClass(), "'b' is a CompBImpl");
-
-		assertNotNull(inj.getOrThrow(CompBImpl.class).wrapped, "Test wrapped instance");
-		assertNotNull(inj.getOrThrow(CompBImpl.class).wrapped2, "Test wrapped2 instance");
-		assertEquals(CompAImpl.class, inj.getOrThrow(CompBImpl.class).wrapped.getClass(), "Test wrapped instance type");
-		assertEquals(CompAImpl2.class, inj.getOrThrow(CompBImpl.class).wrapped2.getClass(), "Test wrapped2 instance type (most recent added)");
-
-		assertNotNull(((CompBImpl) inj.getOrThrow("b")).wrapped, "Test wrapped instance");
-		assertNotNull(((CompBImpl) inj.getOrThrow("b")).wrapped2, "Test wrapped2 instance");
-		assertEquals(CompAImpl.class, ((CompBImpl) inj.getOrThrow("b")).wrapped.getClass(), "Test wrapped instance type");
-		assertEquals(CompAImpl2.class, ((CompBImpl) inj.getOrThrow("b")).wrapped2.getClass(), "Test wrapped2 instance type (most recent added)");
-	}
-
-	@Test
-	@DisplayName(".get(String)")
-	public void getQualifier()
-	{
-		final Injector inj = Injector.builder().fromProviders().build();
-
-		assertTrue(inj.get("a").isPresent(), "'a' qualifier");
-		assertTrue(inj.get("b").isPresent(), "'b' qualifier");
-		assertFalse(inj.get("c").isPresent(), "'c' qualifier");
-	}
+        assertTrue(inj.get("a").isPresent(), "'a' qualifier");
+        assertTrue(inj.get("b").isPresent(), "'b' qualifier");
+        assertFalse(inj.get("c").isPresent(), "'c' qualifier");
+    }
 }

--- a/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
+++ b/src/test/java/com/github/pyknic/stiletto/InjectorAnnotationTest.java
@@ -1,0 +1,189 @@
+/**
+ *
+ * Copyright (c) 2017, Emil Forslund. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); You may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.github.pyknic.stiletto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Simon Jonasson
+ * @since 1.0.2
+ */
+@DisplayName("InjectorAnnotation")
+public class InjectorAnnotationTest
+{
+
+	private interface CompA
+	{
+	}
+
+	private interface CompB
+	{
+	}
+
+	private interface CompC
+	{
+	}
+
+	@Provider("a")
+	private static final class CompAImpl implements CompA
+	{
+	}
+
+	@Provider("a2")
+	private static final class CompAImpl2 implements CompA
+	{
+	}
+
+	@Provider("b")
+	private static final class CompBImpl implements CompA, CompB
+	{
+		private final CompA wrapped;
+		private final CompA wrapped2;
+
+		// Should not be invoked.
+		CompBImpl()
+		{
+			wrapped = null;
+			wrapped2 = null;
+		}
+
+		@Inject
+		CompBImpl(@Inject("a") CompA wrapped, CompA second)
+		{
+			this.wrapped = wrapped;
+			this.wrapped2 = second;
+		}
+	}
+
+	@Test
+	@DisplayName(".has(Class)")
+	public void has()
+	{
+		final Injector inj = Injector.builder().fromProviders().build();
+
+		assertTrue(inj.has(CompA.class), "CompA interface");
+		assertTrue(inj.has(CompB.class), "CompB interface");
+		assertFalse(inj.has(CompC.class), "CompC interface");
+
+		assertTrue(inj.has(CompAImpl.class), "CompA class");
+		assertTrue(inj.has(CompBImpl.class), "CompB class");
+	}
+
+	@Test
+	@DisplayName(".getOrThrow(Class)")
+	public void getOrThrow()
+	{
+		final Injector inj = Injector.builder().fromProviders().build();
+
+		assertNotNull(inj.getOrThrow(CompA.class), "CompA interface");
+		assertNotNull(inj.getOrThrow(CompB.class), "CompB interface");
+		assertNotNull(inj.getOrThrow(CompAImpl.class), "CompA class");
+		assertNotNull(inj.getOrThrow(CompBImpl.class), "CompB class");
+		assertThrows(InjectorException.class, () -> {
+			inj.getOrThrow(CompC.class);
+		});
+
+		assertEquals(CompBImpl.class, inj.getOrThrow(CompA.class).getClass(), "CompA is a CompBImpl (most recent added)");
+		assertEquals(CompBImpl.class, inj.getOrThrow(CompB.class).getClass(), "CompB is a CompBImpl");
+
+		assertNotNull(inj.getOrThrow(CompBImpl.class).wrapped, "Test wrapped instance");
+		assertEquals(CompAImpl.class, inj.getOrThrow(CompBImpl.class).wrapped.getClass(), "Test wrapped instance type");
+	}
+
+	@Test
+	@DisplayName(".get(Class)")
+	public void get()
+	{
+		final Injector inj = Injector.builder().fromProviders().build();
+
+		assertTrue(inj.get(CompA.class).isPresent(), "CompA interface");
+		assertTrue(inj.get(CompB.class).isPresent(), "CompB interface");
+		assertFalse(inj.get(CompC.class).isPresent(), "CompC interface");
+
+		assertTrue(inj.get(CompAImpl.class).isPresent(), "CompA class");
+		assertTrue(inj.get(CompBImpl.class).isPresent(), "CompB class");
+	}
+
+	@Test
+	@DisplayName(".has(String)")
+	public void hasQualifier()
+	{
+		final Injector inj = Injector.builder().fromProviders().build();
+
+		assertTrue(inj.has("a"), "'a' qualifier");
+		assertTrue(inj.has("a2"), "'a2' qualifier");
+		assertTrue(inj.has("b"), "'b' qualifier");
+		assertFalse(inj.has("c"), "'c' qualifier");
+	}
+
+	@Test
+	@DisplayName(".getOrThrow(String)")
+	public void getOrThrowQualifier()
+	{
+		final Injector inj = Injector.builder().fromProviders().build();
+
+		assertNotNull(inj.getOrThrow(CompA.class), "CompA interface");
+		assertNotNull(inj.getOrThrow(CompB.class), "CompB interface");
+		assertNotNull(inj.getOrThrow(CompAImpl.class), "CompA class");
+		assertNotNull(inj.getOrThrow(CompBImpl.class), "CompB class");
+		assertThrows(InjectorException.class, () -> {
+			inj.getOrThrow(CompC.class);
+		});
+
+		assertNotNull(inj.getOrThrow("a"), "'a' qualifier");
+		assertNotNull(inj.getOrThrow("a2"), "'a2' qualifier");
+		assertNotNull(inj.getOrThrow("b"), "'b' qualifier");
+		assertThrows(InjectorException.class, () -> {
+			inj.getOrThrow("c");
+		});
+
+		assertEquals(CompBImpl.class, inj.getOrThrow(CompA.class).getClass(), "CompA is a CompBImpl (most recent added)");
+		assertEquals(CompBImpl.class, inj.getOrThrow(CompB.class).getClass(), "CompB is a CompBImpl");
+
+		assertEquals(CompAImpl.class, inj.getOrThrow("a").getClass(), "'a' is a CompAImpl");
+		assertEquals(CompAImpl2.class, inj.getOrThrow("a2").getClass(), "'a2' is a CompAImpl2");
+		assertEquals(CompBImpl.class, inj.getOrThrow("b").getClass(), "'b' is a CompBImpl");
+
+		assertNotNull(inj.getOrThrow(CompBImpl.class).wrapped, "Test wrapped instance");
+		assertNotNull(inj.getOrThrow(CompBImpl.class).wrapped2, "Test wrapped2 instance");
+		assertEquals(CompAImpl.class, inj.getOrThrow(CompBImpl.class).wrapped.getClass(), "Test wrapped instance type");
+		assertEquals(CompAImpl2.class, inj.getOrThrow(CompBImpl.class).wrapped2.getClass(), "Test wrapped2 instance type (most recent added)");
+
+		assertNotNull(((CompBImpl) inj.getOrThrow("b")).wrapped, "Test wrapped instance");
+		assertNotNull(((CompBImpl) inj.getOrThrow("b")).wrapped2, "Test wrapped2 instance");
+		assertEquals(CompAImpl.class, ((CompBImpl) inj.getOrThrow("b")).wrapped.getClass(), "Test wrapped instance type");
+		assertEquals(CompAImpl2.class, ((CompBImpl) inj.getOrThrow("b")).wrapped2.getClass(), "Test wrapped2 instance type (most recent added)");
+	}
+
+	@Test
+	@DisplayName(".get(String)")
+	public void getQualifier()
+	{
+		final Injector inj = Injector.builder().fromProviders().build();
+
+		assertTrue(inj.get("a").isPresent(), "'a' qualifier");
+		assertTrue(inj.get("b").isPresent(), "'b' qualifier");
+		assertFalse(inj.get("c").isPresent(), "'c' qualifier");
+	}
+}

--- a/src/test/java/com/github/pyknic/stiletto/InjectorTest.java
+++ b/src/test/java/com/github/pyknic/stiletto/InjectorTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since  1.0.0
  */
 @DisplayName("Injector")
-public class InjectorTest {
+class InjectorTest {
 
     private interface CompA {}
     private interface CompB {}

--- a/src/test/java/com/github/pyknic/stiletto/InjectorTest.java
+++ b/src/test/java/com/github/pyknic/stiletto/InjectorTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since  1.0.0
  */
 @DisplayName("Injector")
-class InjectorTest {
+public class InjectorTest {
 
     private interface CompA {}
     private interface CompB {}
@@ -53,7 +53,7 @@ class InjectorTest {
 
     @Test
     @DisplayName(".has(Class)")
-    void has() {
+    public void has() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompBImpl.class)
@@ -69,7 +69,7 @@ class InjectorTest {
 
     @Test
     @DisplayName(".getOrThrow(Class)")
-    void getOrThrow() {
+    public void getOrThrow() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompBImpl.class)
@@ -92,7 +92,7 @@ class InjectorTest {
 
     @Test
     @DisplayName(".get(Class)")
-    void get() {
+    public void get() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompBImpl.class)
@@ -108,7 +108,7 @@ class InjectorTest {
 
     @Test
     @DisplayName(".has(String)")
-    void hasQualifier() {
+    public void hasQualifier() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompAImpl2.class, "a2")
@@ -123,7 +123,7 @@ class InjectorTest {
 
     @Test
     @DisplayName(".getOrThrow(String)")
-    void getOrThrowQualifier() {
+    public void getOrThrowQualifier() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompAImpl2.class, "a2")
@@ -165,7 +165,7 @@ class InjectorTest {
 
     @Test
     @DisplayName(".get(String)")
-    void getQualifier() {
+    public void getQualifier() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompBImpl.class, "b")

--- a/src/test/java/com/github/pyknic/stiletto/InjectorTest.java
+++ b/src/test/java/com/github/pyknic/stiletto/InjectorTest.java
@@ -53,7 +53,7 @@ public class InjectorTest {
 
     @Test
     @DisplayName(".has(Class)")
-    public void has() {
+    void has() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompBImpl.class)
@@ -69,7 +69,7 @@ public class InjectorTest {
 
     @Test
     @DisplayName(".getOrThrow(Class)")
-    public void getOrThrow() {
+    void getOrThrow() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompBImpl.class)
@@ -92,7 +92,7 @@ public class InjectorTest {
 
     @Test
     @DisplayName(".get(Class)")
-    public void get() {
+    void get() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompBImpl.class)
@@ -108,7 +108,7 @@ public class InjectorTest {
 
     @Test
     @DisplayName(".has(String)")
-    public void hasQualifier() {
+    void hasQualifier() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompAImpl2.class, "a2")
@@ -123,7 +123,7 @@ public class InjectorTest {
 
     @Test
     @DisplayName(".getOrThrow(String)")
-    public void getOrThrowQualifier() {
+    void getOrThrowQualifier() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompAImpl2.class, "a2")
@@ -165,7 +165,7 @@ public class InjectorTest {
 
     @Test
     @DisplayName(".get(String)")
-    public void getQualifier() {
+    void getQualifier() {
         final Injector inj = Injector.builder()
             .withType(CompAImpl.class, "a")
             .withType(CompBImpl.class, "b")

--- a/src/test/java/com/github/pyknic/stiletto/testtype/CompA.java
+++ b/src/test/java/com/github/pyknic/stiletto/testtype/CompA.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Emil Forslund.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pyknic.stiletto.testtype;
+
+/**Interface for testing
+ *
+ * @author Simon Jonasson
+ * @since 1.0.3
+ */
+public interface CompA {
+    
+}

--- a/src/test/java/com/github/pyknic/stiletto/testtype/CompAImpl.java
+++ b/src/test/java/com/github/pyknic/stiletto/testtype/CompAImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Emil Forslund.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pyknic.stiletto.testtype;
+
+import com.github.pyknic.stiletto.Provider;
+
+/**
+ *
+ * @author Simon Jonasson
+ * @since 1.0.3
+ */
+@Provider("a")
+public class CompAImpl implements CompA{
+    
+}

--- a/src/test/java/com/github/pyknic/stiletto/testtype/CompAImpl.java
+++ b/src/test/java/com/github/pyknic/stiletto/testtype/CompAImpl.java
@@ -15,6 +15,7 @@
  */
 package com.github.pyknic.stiletto.testtype;
 
+import com.github.pyknic.stiletto.testtype.CompA;
 import com.github.pyknic.stiletto.Provider;
 
 /**

--- a/src/test/java/com/github/pyknic/stiletto/testtype/CompAImpl2.java
+++ b/src/test/java/com/github/pyknic/stiletto/testtype/CompAImpl2.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Emil Forslund.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pyknic.stiletto.testtype;
+
+import com.github.pyknic.stiletto.Provider;
+
+/**
+ *
+ * @author Simon Jonasson
+ * @since 1.0.3
+ */
+@Provider("a2")
+public class CompAImpl2 implements CompA{
+    
+}

--- a/src/test/java/com/github/pyknic/stiletto/testtype/CompAImpl2.java
+++ b/src/test/java/com/github/pyknic/stiletto/testtype/CompAImpl2.java
@@ -15,6 +15,7 @@
  */
 package com.github.pyknic.stiletto.testtype;
 
+import com.github.pyknic.stiletto.testtype.CompA;
 import com.github.pyknic.stiletto.Provider;
 
 /**

--- a/src/test/java/com/github/pyknic/stiletto/testtype/CompB.java
+++ b/src/test/java/com/github/pyknic/stiletto/testtype/CompB.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Emil Forslund.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pyknic.stiletto.testtype;
+
+/**Interface for testing
+ * 
+ * @author Simon Jonasson
+ * @since 1.0.3
+ */
+public interface CompB {
+    
+}

--- a/src/test/java/com/github/pyknic/stiletto/testtype/CompBImpl.java
+++ b/src/test/java/com/github/pyknic/stiletto/testtype/CompBImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Emil Forslund.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pyknic.stiletto.testtype;
+
+import com.github.pyknic.stiletto.Inject;
+import com.github.pyknic.stiletto.Provider;
+
+/**
+ * @author Simon Jonasson
+ * @since 1.0.3
+ */
+@Provider("b")
+public class CompBImpl implements CompA, CompB{
+    public final CompA wrapped;
+    public final CompA wrapped2;
+
+    // Should not be invoked.
+    CompBImpl() {
+        wrapped = null;
+        wrapped2 = null;
+    }
+
+    @Inject
+    CompBImpl(@Inject("a") CompA wrapped, CompA second) {
+        this.wrapped  = wrapped;
+        this.wrapped2 = second;
+    }
+}

--- a/src/test/java/com/github/pyknic/stiletto/testtype/CompBImpl.java
+++ b/src/test/java/com/github/pyknic/stiletto/testtype/CompBImpl.java
@@ -15,6 +15,8 @@
  */
 package com.github.pyknic.stiletto.testtype;
 
+import com.github.pyknic.stiletto.testtype.CompB;
+import com.github.pyknic.stiletto.testtype.CompA;
 import com.github.pyknic.stiletto.Inject;
 import com.github.pyknic.stiletto.Provider;
 

--- a/src/test/java/com/github/pyknic/stiletto/testtype/CompC.java
+++ b/src/test/java/com/github/pyknic/stiletto/testtype/CompC.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Emil Forslund.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pyknic.stiletto.testtype;
+
+/**Interface for testing
+ *
+ * @author Simon Jonasson
+ * @since 1.0.3
+ */
+public interface CompC {
+    
+}


### PR DESCRIPTION
This pull request will add the ability to add an annotation to a class, indicating that that class should be incorporated into the Injector, if the injector is built with the `fromProviders(String... scanSpecs)` method. 

This removes the need for manually listing all types that should be part of the injector. With the `scanSpecs` parameter, users can also note the scanners root-node. This allows the user to control which packages are scanned for `@Provider` annotations.

The test suit for this feature resides in the class `InjectorAnnotationTest `. The class is in large a copy of `InjectorTest `, but with one new method (for testing the setting of scanner root, and making sure we discover/don't discover the correct types), and with classes and interfaces added to the injector via annotations (instead of explicitly).

**Worth discussing**
Dependancy injection is a very useful tool for testing. I did consider adding a 2nd annotation, `TestProvider`, to let users separate which types should be injected when running tests. Instead, I went with the ability to control which packages are scanned for injectable types. Is this the correct choice? 